### PR TITLE
Add inlay hints for instruction references

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
     <textarea id="codeInput" placeholder="Enter your code here..."></textarea>
     <div id="highlightedCode"></div>
+    <div id="inlayHints"></div>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,8 @@ document.getElementById('codeInput').addEventListener('input', function() {
     const code = this.value;
     const highlightedCode = highlightSyntax(code);
     document.getElementById('highlightedCode').innerHTML = highlightedCode;
+    const inlayHints = generateInlayHints(code);
+    document.getElementById('inlayHints').innerHTML = inlayHints;
 });
 
 function highlightSyntax(code) {
@@ -14,4 +16,20 @@ function highlightSyntax(code) {
         .replace(commentRegex, '<span class="comment">$&</span>')
         .replace(keywordRegex, '<span class="keyword">$&</span>')
         .replace(numberRegex, '<span class="number">$&</span>');
+}
+
+function generateInlayHints(code) {
+    const lines = code.split('\n');
+    let hints = '';
+
+    lines.forEach((line, index) => {
+        const match = line.match(/(JUMP|JUMPZ|JUMPG|COPY|ICOPY|DECSKIP)\s+(-?\d+)/);
+        if (match) {
+            const instruction = match[1];
+            const argument = match[2];
+            hints += `<div class="inlay-hint">Line ${index + 1}: ${instruction} references line ${index + 1 + parseInt(argument)}</div>`;
+        }
+    });
+
+    return hints;
 }

--- a/styles.css
+++ b/styles.css
@@ -41,3 +41,12 @@ textarea {
     color: #6a737d;
     font-style: italic;
 }
+
+.inlay-hint {
+    background-color: #e7f3ff;
+    border-left: 4px solid #007bff;
+    padding: 5px;
+    margin: 5px 0;
+    font-size: 14px;
+    color: #333;
+}


### PR DESCRIPTION
Add support for displaying references to instructions within the program through inlay hints.

* **index.html**
  - Add a container for displaying inlay hints below the `highlightedCode` div.

* **script.js**
  - Add functionality to identify instructions with arguments that reference other instructions.
  - Add functionality to display inlay hints for identified references.

* **styles.css**
  - Add styles for inlay hints to make them visually distinct.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bstncartwright/hcf-code-editor?shareId=9690e0b6-7e19-4b18-92c1-27d094a65284).